### PR TITLE
Erro na fase de treinamento

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -5,5 +5,6 @@ sklearn-crfsuite==0.3.6
 nltk==3.4.5
 rocketchat-py-sdk==0.0.8
 elasticsearch==6.3.1
+tornado
 
 


### PR DESCRIPTION
python3 train.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/socketio/tornado.py", line 4, in <module>
    from engineio.async_drivers.tornado import get_tornado_handler as \
  File "/usr/local/lib/python3.6/site-packages/engineio/async_drivers/tornado.py", line 6, in <module>
    import tornado.web
ModuleNotFoundError: No module named 'tornado'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "train.py", line 23, in <module>
    train_dialogue('domain.yml', '/src_models/dialogue', 'data/stories/', 'policy_config.yml')
  File "train.py", line 19, in train_dialogue
    'validation_split': 0.2,}
  File "/usr/local/lib/python3.6/site-packages/rasa_core/train.py", line 66, in train
    from rasa_core.agent import Agent
  File "/usr/local/lib/python3.6/site-packages/rasa_core/agent.py", line 14, in <module>
    from rasa_core.channels import UserMessage, OutputChannel, InputChannel
  File "/usr/local/lib/python3.6/site-packages/rasa_core/channels/__init__.py", line 11, in <module>
    from rasa_core.channels.socketio import SocketIOInput
  File "/usr/local/lib/python3.6/site-packages/rasa_core/channels/socketio.py", line 5, in <module>
    import socketio
  File "/usr/local/lib/python3.6/site-packages/socketio/__init__.py", line 12, in <module>
    from .tornado import get_tornado_handler
  File "/usr/local/lib/python3.6/site-packages/socketio/tornado.py", line 7, in <module>
    from engineio.async_tornado import get_tornado_handler as \
ModuleNotFoundError: No module named 'engineio.async_tornado'
make: *** [Makefile:6: train-core] Error 1
The command '/bin/sh -c make train' returned a non-zero code: 2
Makefile:8: recipe for target 'train' failed
make[1]: *** [train] Error 2
make[1]: Leaving directory '/home/dipelnetfoz/lappisudo'
Makefile:2: recipe for target 'first-run' failed
make: *** [first-run] Error 2
